### PR TITLE
WARP-5840: Add basic MDIO read/write support

### DIFF
--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -5,6 +5,8 @@
  * Copyright (C) 2010 Lantiq Deutschland
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
+ * Copyright (C) 2022 Reliable Controls Corporation,
+ * 						Harley Sims <hsims@reliablecontrols.com>
  *
  * The VLAN and bridge model the GSWIP hardware uses does not directly
  * matches the model DSA uses.
@@ -279,8 +281,10 @@ struct gswip_priv {
 };
 
 struct gsw_ops {
-	u32 (*read)(struct gswip_priv *priv, void *address);
-	void (*write)(struct gswip_priv *priv, u32 val, void *address);
+	u32 (*read)(struct gswip_priv *priv, void *addr);
+	u32 (*read_timeout)(struct gswip_priv *priv, void *addr, \
+					u32 cleared, u32 sleep_us, u32 timeout_us);
+	void (*write)(struct gswip_priv *priv, void *addr, u32 val);
 };
 
 struct gswip_pce_table_entry {

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -5,7 +5,8 @@
  * Copyright (C) 2010 Lantiq Deutschland
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
- * Copyright (C) 2022 Reliable Controls Corporation, Harley Sims <hsims@reliablecontrols.com>
+ * Copyright (C) 2022 Reliable Controls Corporation,
+ * 					Harley Sims <hsims@reliablecontrols.com>
  *
  * The VLAN and bridge model the GSWIP hardware uses does not directly
  * matches the model DSA uses.
@@ -102,7 +103,7 @@ static u32 gswip_switch_r(struct gswip_priv *priv, u32 offset)
 
 static void gswip_switch_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, val, (priv->gswip + (offset * 4)));
+	priv->ops->write(priv, (priv->gswip + (offset * 4)), val);
 }
 
 static void gswip_switch_mask(struct gswip_priv *priv, u32 clear, u32 set,
@@ -118,12 +119,8 @@ static void gswip_switch_mask(struct gswip_priv *priv, u32 clear, u32 set,
 static u32 gswip_switch_r_timeout(struct gswip_priv *priv, u32 offset,
 				  u32 cleared)
 {
-	/* TODO WARP-5829: re-write this function */
-	//u32 val;
-
-	//return readx_poll_timeout(priv->ops->read, (priv->gswip + (offset * 4)),
-	//			  val, (val & cleared) == 0, 20, 50000);
-	return 0;
+	return priv->ops->read_timeout(priv, (priv->gswip + (offset * 4)), \
+								cleared, 20, 50000);
 }
 
 static u32 gswip_slave_mdio_r(struct gswip_priv *priv, u32 offset)
@@ -133,7 +130,7 @@ static u32 gswip_slave_mdio_r(struct gswip_priv *priv, u32 offset)
 
 static void gswip_slave_mdio_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, val, (priv->mdio + (offset * 4)));
+	priv->ops->write(priv, (priv->mdio + (offset * 4)), val);
 }
 
 static void gswip_slave_mdio_mask(struct gswip_priv *priv, u32 clear, u32 set,
@@ -153,7 +150,7 @@ static u32 gswip_mii_r(struct gswip_priv *priv, u32 offset)
 
 static void gswip_mii_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, val, (priv->mii + (offset * 4)));
+	priv->ops->write(priv, (priv->mii + (offset * 4)), val);
 }
 
 static void gswip_mii_mask(struct gswip_priv *priv, u32 clear, u32 set,

--- a/drivers/net/dsa/lantiq_gsw_mdio.c
+++ b/drivers/net/dsa/lantiq_gsw_mdio.c
@@ -44,12 +44,12 @@ struct gsw_mdio {
 	struct gswip_priv common;
 };
 
-static u32 gsw_mdio_read_actual(struct mdio_device *mdio, u32 reg)
+static inline u32 gsw_mdio_read_actual(struct mdio_device *mdio, u32 reg)
 {
 	return mdio->bus->read(mdio->bus, mdio->addr, reg);
 }
 
-static void gsw_mdio_write_actual(struct mdio_device *mdio, u32 reg, u32 val)
+static inline void gsw_mdio_write_actual(struct mdio_device *mdio, u32 reg, u32 val)
 {
 	mdio->bus->write(mdio->bus, mdio->addr, reg, val);
 }

--- a/drivers/net/dsa/lantiq_gsw_mdio.c
+++ b/drivers/net/dsa/lantiq_gsw_mdio.c
@@ -8,7 +8,8 @@
  * Copyright (C) 2010 Lantiq Deutschland
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
- * Copyright (C) 2022 Reliable Controls Corporation, Harley Sims <hsims@reliablecontrols.com>
+ * Copyright (C) 2022 Reliable Controls Corporation,
+ * 						Harley Sims <hsims@reliablecontrols.com>
  */
 
 /* TODO WARP-5829: determine how many of these includes I can delete */
@@ -35,19 +36,103 @@
 #include "lantiq_gsw.h"
 #include "lantiq_pce.h"
 
-static u32 gsw_mdio_read(struct gswip_priv *priv, void *address)
+#define NUM_ACCESSIBLE_REGS (30)
+#define TARGET_BASE_ADDRESS_REG (31)
+
+struct gsw_mdio {
+	struct mdio_device *mdio_dev;
+	struct gswip_priv common;
+};
+
+static u32 gsw_mdio_read_actual(struct mdio_device *mdio, u32 reg)
 {
-	/* TODO WARP-5829: write this function */
-	return 0;
+	return mdio->bus->read(mdio->bus, mdio->addr, reg);
 }
 
-static void gsw_mdio_write(struct gswip_priv *priv, u32 val, void *address)
+static void gsw_mdio_write_actual(struct mdio_device *mdio, u32 reg, u32 val)
 {
-	/* TODO WARP-5829: write this function */
+	mdio->bus->write(mdio->bus, mdio->addr, reg, val);
+}
+
+static inline u32 gsw_mdio_read_tbar(struct mdio_device *mdio)
+{
+	return gsw_mdio_read_actual(mdio, TARGET_BASE_ADDRESS_REG);
+}
+
+static inline void gsw_mdio_write_tbar(struct mdio_device *mdio, u32 reg_addr)
+{
+	gsw_mdio_write_actual(mdio, TARGET_BASE_ADDRESS_REG, reg_addr);
+}
+
+static u32 gsw_mdio_check_write_tbar(struct mdio_device *mdio, u32 reg_addr)
+{
+	u32 tbar = gsw_mdio_read_tbar(mdio);
+
+	/* MDIO slave interface uses an indirect addressing scheme that allows
+	 * access to NUM_ACCESSIBLE_REGS registers at a time. The Target Base
+	 * Address Register (TBAR) is used to set a base offset, then MDIO
+	 * registers (0-30) are used to access internal addresses of (TBAR + 0-30)
+	 */
+	if ((reg_addr < tbar) || (reg_addr > (tbar + NUM_ACCESSIBLE_REGS))) {
+			gsw_mdio_write_tbar(mdio, reg_addr);
+			tbar = reg_addr;
+	}
+
+	return tbar;
+}
+
+static u32 gsw_mdio_read(struct gswip_priv *priv, void *addr)
+{
+	struct mdio_device *mdio;
+	u32 reg_addr, tbar, val;
+
+	mdio = ((struct gsw_mdio *)dev_get_drvdata(priv->dev))->mdio_dev;
+	reg_addr = (u32)addr;
+
+	mutex_lock(&mdio->bus->mdio_lock);
+	tbar = gsw_mdio_check_write_tbar(mdio, reg_addr);
+	val = gsw_mdio_read_actual(mdio, (reg_addr - tbar));
+	mutex_unlock(&mdio->bus->mdio_lock);
+
+	return val;
+}
+
+static u32 gsw_mdio_read_timeout(struct gswip_priv *priv, void *addr,
+								u32 cleared, u32 sleep_us, u32 timeout_us)
+{
+	struct mdio_device *mdio;
+	u32 retval, reg_addr, tbar, val;
+
+	mdio = ((struct gsw_mdio *)dev_get_drvdata(priv->dev))->mdio_dev;
+	reg_addr = (u32)addr;
+
+	mutex_lock(&mdio->bus->mdio_lock);
+	tbar = gsw_mdio_check_write_tbar(mdio, reg_addr);
+	retval = read_poll_timeout(gsw_mdio_read_actual, val, \
+				(val & cleared) == 0, sleep_us, timeout_us, false, \
+				mdio, (reg_addr - tbar));
+	mutex_unlock(&mdio->bus->mdio_lock);
+
+	return retval;
+}
+
+static void gsw_mdio_write(struct gswip_priv *priv, void *addr, u32 val)
+{
+	struct mdio_device *mdio;
+	u32 reg_addr, tbar;
+
+	mdio = ((struct gsw_mdio *)dev_get_drvdata(priv->dev))->mdio_dev;
+	reg_addr = (u32)addr;
+
+	mutex_lock(&mdio->bus->mdio_lock);
+	tbar = gsw_mdio_check_write_tbar(mdio, reg_addr);
+	gsw_mdio_write_actual(mdio, (reg_addr - tbar), val);
+	mutex_unlock(&mdio->bus->mdio_lock);
 }
 
 static const struct gsw_ops gsw_mdio_ops = {
 	.read = gsw_mdio_read,
+	.read_timeout = gsw_mdio_read_timeout,
 	.write = gsw_mdio_write,
 };
 

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -5,7 +5,8 @@
  * Copyright (C) 2010 Lantiq Deutschland
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
- * Copyright (C) 2022 Reliable Controls Corporation, Harley Sims <hsims@reliablecontrols.com>
+ * Copyright (C) 2022 Reliable Controls Corporation,
+ * 						Harley Sims <hsims@reliablecontrols.com>
  */
 
 /* TODO WARP-5829: determine how many of these includes I can delete */
@@ -32,22 +33,36 @@
 #include "lantiq_gsw.h"
 #include "lantiq_pce.h"
 
-static u32 gsw_platform_read(struct gswip_priv *priv, void *address)
+struct gsw_platform {
+	struct platform_device *platform_dev;
+	struct gswip_priv common;
+};
+
+static u32 gsw_platform_read(struct gswip_priv *priv, void *addr)
 {
-	/* TODO WARP-5829: finalize this function */
 	(void*)priv;
-	return __raw_readl(address);
+	return __raw_readl(addr);
 }
 
-static void gsw_platform_write(struct gswip_priv *priv, u32 val, void *address)
+static u32 gsw_platform_read_timeout(struct gswip_priv *priv, void *addr, 
+								u32 cleared, u32 sleep_us, u32 timeout_us)
 {
-	/* TODO WARP-5829: finalize this function */
+	u32 val;
+	
 	(void*)priv;
-	__raw_writel(val, address);
+	return readx_poll_timeout(__raw_readl, addr, val,
+						(val & cleared) == 0, sleep_us, timeout_us);
+}
+
+static void gsw_platform_write(struct gswip_priv *priv, void *addr, u32 val)
+{
+	(void*)priv;
+	__raw_writel(val, addr);
 }
 
 static const struct gsw_ops gsw_platform_ops = {
 	.read = gsw_platform_read,
+	.read_timeout = gsw_platform_read_timeout,
 	.write = gsw_platform_write,
 };
 

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -40,7 +40,7 @@ struct gsw_platform {
 
 static u32 gsw_platform_read(struct gswip_priv *priv, void *addr)
 {
-	(void*)priv;
+	(void)priv;
 	return __raw_readl(addr);
 }
 
@@ -49,14 +49,14 @@ static u32 gsw_platform_read_timeout(struct gswip_priv *priv, void *addr,
 {
 	u32 val;
 	
-	(void*)priv;
+	(void)priv;
 	return readx_poll_timeout(__raw_readl, addr, val,
 						(val & cleared) == 0, sleep_us, timeout_us);
 }
 
 static void gsw_platform_write(struct gswip_priv *priv, void *addr, u32 val)
 {
-	(void*)priv;
+	(void)priv;
 	__raw_writel(val, addr);
 }
 


### PR DESCRIPTION
NOTE: The MDIO read/write functions are currently untested.
The code compiles, and the MDIO bus accesses work as expected, but the read()/write()/read_timeout() functions have not been executed. Test code will be written in WARP-5855 and any issues that are found will be fixed there. This is because I need to get the probe function working to an extent before testing can be done (which will be done in WARP-5853).

- Implement MDIO-specific read/write, using procedures outlined in the GSW datasheet as a guide. Protect against concurrent access via MDIO bus mutex, and always check/write TBAR to protect against part reset or other unexpected corruption.
- Implement platform driver-specific read/write, based on the implementations from the existing driver.
- Move read w/ timeout to be driver specific, keeping timeout and sleep values in core calls to make specific functions reusable in different situations.