### PR TITLE
WARP-5853: Implement probe function for MDIO driver

### DIFF
--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -307,7 +307,7 @@ struct gswip_rmon_cnt_desc {
 
 #define MIB_DESC(_size, _offset, _name) {.size = _size, .offset = _offset, .name = _name}
 
-int gsw_core_probe(struct platform_device *pdev);
+int gsw_core_probe(struct gswip_priv *priv, struct device *dev);
 int gsw_core_remove(struct gswip_priv *priv);
 
 #endif

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -1784,14 +1784,17 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 	priv->dev = dev;
 
 	/* TODO WARP-5828:
-	 * do the external parts have versioning? move to platform probe if not.
+	 * do the external parts have versioning?
+	 * determine where to put this & uncomment
 	 */
-	version = gswip_switch_r(priv, GSWIP_VERSION);
+	//version = gswip_switch_r(priv, GSWIP_VERSION);
 
 	/* TODO WARP-5828:
-	 * determine if this is applicable, move to platform probe if not.
+	 * determine if this is applicable to external parts
+	 * determine where to put this & uncomment
 	 */
-	gphy_fw_np = of_get_compatible_child(dev->of_node, "lantiq,gphy-fw");
+/*
+  	gphy_fw_np = of_get_compatible_child(dev->of_node, "lantiq,gphy-fw");
 	if (gphy_fw_np) {
 		err = gswip_gphy_fw_list(priv, gphy_fw_np, version);
 		of_node_put(gphy_fw_np);
@@ -1800,10 +1803,13 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 			return err;
 		}
 	}
+*/
 
 	/* TODO WARP-5828:
 	 * determine if this is applicable, move to platform probe if not.
+	 * uncomment wherever it ends up.
 	 */
+/* 	
 	mdio_np = of_get_compatible_child(dev->of_node, "lantiq,xrx200-mdio");
 	if (mdio_np) {
 		err = gswip_slave_mdio(priv, mdio_np);
@@ -1812,7 +1818,12 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 			goto put_mdio_node;
 		}
 	}
+ */
 
+	/* TODO WARP-5828:
+	 * get register mapping corrected and uncomment
+	 */
+/*
 	err = dsa_register_switch(priv->ds);
 	if (err) {
 		dev_err(dev, "dsa switch register failed: %i\n", err);
@@ -1828,6 +1839,7 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 	dev_info(dev, "probed GSWIP version %lx mod %lx\n",
 		 (version & GSWIP_VERSION_REV_MASK) >> GSWIP_VERSION_REV_SHIFT,
 		 (version & GSWIP_VERSION_MOD_MASK) >> GSWIP_VERSION_MOD_SHIFT);
+*/
 	return 0;
 
 disable_switch:

--- a/drivers/net/dsa/lantiq_gsw_mdio.c
+++ b/drivers/net/dsa/lantiq_gsw_mdio.c
@@ -138,19 +138,29 @@ static const struct gsw_ops gsw_mdio_ops = {
 
 /*-------------------------------------------------------------------------*/
 
-static int gsw_mdio_probe(struct mdio_device *pmdiodev)
+static int gsw_mdio_probe(struct mdio_device *mdiodev)
 {
-	/* TODO WARP-5829: write this function */
-	printk("!RCC: GSW MDIO probe func invoked.\n");
-	dev_err(&(pmdiodev->dev), "GSW120 SUPPORT NOT YET IMPLEMENTED\n");
+	struct device *dev = &(mdiodev->dev);
+	struct gsw_mdio *mdio_data;
+	int err;
 
-	return EFAULT;
+	mdio_data = devm_kzalloc(dev, sizeof(*mdio_data), GFP_KERNEL);
+	if (!mdio_data)
+		return -ENOMEM;
+
+	err = gsw_core_probe(&mdio_data->common, dev);
+	if (err)
+		return err;
+
+	dev_set_drvdata(dev, mdio_data);
+
+	return 0;
 }
 
 static void gsw_mdio_remove(struct mdio_device *pmdiodev)
 {
-	/* TODO WARP-5829: verify nothing else needs to be done in this function */
-	gsw_core_remove((struct gswip_priv*)mdiodev_get_drvdata(pmdiodev));
+	struct gsw_mdio *mdio_data = mdiodev_get_drvdata(pmdiodev);
+	gsw_core_remove(&mdio_data->common);
 }
 
 /*-------------------------------------------------------------------------*/
@@ -160,9 +170,6 @@ static const struct gsw_hw_info gsw_120 = {
 	/* TODO WARP-5828: Determine what these values should be */
 	.max_ports = 4,
 	.cpu_port = 1,
-	/* TODO WARP-5826: will also need .ops for newer kernel versions,
-	 * where parts have had their DSA operations broken out.
-	 */
 };
 
 static const struct of_device_id gsw_mdio_of_match[] = {

--- a/drivers/net/dsa/lantiq_gsw_mdio.c
+++ b/drivers/net/dsa/lantiq_gsw_mdio.c
@@ -148,11 +148,14 @@ static int gsw_mdio_probe(struct mdio_device *mdiodev)
 	if (!mdio_data)
 		return -ENOMEM;
 
+	mdio_data->common.ops = &gsw_mdio_ops;
+	
+	mdio_data->mdio_dev = mdiodev;
+	dev_set_drvdata(dev, mdio_data);
+
 	err = gsw_core_probe(&mdio_data->common, dev);
 	if (err)
 		return err;
-
-	dev_set_drvdata(dev, mdio_data);
 
 	return 0;
 }

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -78,6 +78,10 @@ static int gsw_platform_probe(struct platform_device *pdev)
 	if (!platform_data)
 		return -ENOMEM;
 
+	platform_data->platform_dev = pdev;
+	platform_set_drvdata(pdev, platform_data);
+
+	platform_data->common.ops = &gsw_platform_ops;
 	platform_data->common.gswip = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(platform_data->common.gswip))
 		return PTR_ERR(platform_data->common.gswip);
@@ -93,8 +97,6 @@ static int gsw_platform_probe(struct platform_device *pdev)
 	err = gsw_core_probe(&platform_data->common, dev);
 	if (err)
 		return err;
-
-	platform_set_drvdata(pdev, platform_data);
 
 	return 0;
 }


### PR DESCRIPTION
- Break platform-specific pieces of existing probe function out into gsw_platform_probe().
- Write gsw_mdio_probe().
- Bring _remove() functions in line with new probe functions.