### PR TITLE
WARP-5855: Test MDIO read/write functions

### DIFF
--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -30,26 +30,6 @@
 #ifndef __LANTIQ_GSW_H
 #define __LANTIQ_GSW_H
 
-#include <linux/clk.h>
-#include <linux/delay.h>
-#include <linux/etherdevice.h>
-#include <linux/firmware.h>
-#include <linux/if_bridge.h>
-#include <linux/if_vlan.h>
-#include <linux/iopoll.h>
-#include <linux/mfd/syscon.h>
-#include <linux/module.h>
-#include <linux/of_mdio.h>
-#include <linux/of_net.h>
-#include <linux/of_platform.h>
-#include <linux/phy.h>
-#include <linux/phylink.h>
-#include <linux/platform_device.h>
-#include <linux/regmap.h>
-#include <linux/reset.h>
-#include <net/dsa.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
-
 /* GSWIP MDIO Registers */
 #define GSWIP_MDIO_GLOB			0x00
 #define  GSWIP_MDIO_GLOB_ENABLE		BIT(15)
@@ -283,7 +263,7 @@ struct gswip_priv {
 struct gsw_ops {
 	u32 (*read)(struct gswip_priv *priv, void *addr);
 	u32 (*read_timeout)(struct gswip_priv *priv, void *addr, \
-					u32 cleared, u32 sleep_us, u32 timeout_us);
+				u32 cleared, u32 sleep_us, u32 timeout_us);
 	void (*write)(struct gswip_priv *priv, void *addr, u32 val);
 };
 

--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -262,9 +262,9 @@ struct gswip_priv {
 
 struct gsw_ops {
 	u32 (*read)(struct gswip_priv *priv, void *addr);
-	u32 (*read_timeout)(struct gswip_priv *priv, void *addr, \
-				u32 cleared, u32 sleep_us, u32 timeout_us);
 	void (*write)(struct gswip_priv *priv, void *addr, u32 val);
+	int (*poll_timeout)(struct gswip_priv *priv, void *addr, \
+			u32 cleared, u32 sleep_us, u32 timeout_us);
 };
 
 struct gswip_pce_table_entry {

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -113,10 +113,10 @@ static void gswip_switch_mask(struct gswip_priv *priv, u32 clear, u32 set,
 	gswip_switch_w(priv, val, offset);
 }
 
-static u32 gswip_switch_r_timeout(struct gswip_priv *priv, u32 offset,
+static int gswip_switch_r_timeout(struct gswip_priv *priv, u32 offset,
 				  u32 cleared)
 {
-	return priv->ops->read_timeout(priv, (priv->gswip + (offset * 4)), \
+	return priv->ops->poll_timeout(priv, (priv->gswip + (offset * 4)), \
 					cleared, 20, 50000);
 }
 

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -6,7 +6,7 @@
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
  * Copyright (C) 2022 Reliable Controls Corporation,
- * 					Harley Sims <hsims@reliablecontrols.com>
+ * 			Harley Sims <hsims@reliablecontrols.com>
  *
  * The VLAN and bridge model the GSWIP hardware uses does not directly
  * matches the model DSA uses.
@@ -27,7 +27,6 @@
  * between all LAN ports by default.
  */
 
-/* TODO WARP-5829: determine how many of these includes I can delete */
 #include <linux/clk.h>
 #include <linux/delay.h>
 #include <linux/etherdevice.h>
@@ -36,13 +35,11 @@
 #include <linux/if_vlan.h>
 #include <linux/iopoll.h>
 #include <linux/mfd/syscon.h>
-#include <linux/module.h>
 #include <linux/of_mdio.h>
 #include <linux/of_net.h>
-#include <linux/of_platform.h>
+#include <linux/of_device.h>
 #include <linux/phy.h>
 #include <linux/phylink.h>
-#include <linux/platform_device.h>
 #include <linux/regmap.h>
 #include <linux/reset.h>
 #include <net/dsa.h>
@@ -120,7 +117,7 @@ static u32 gswip_switch_r_timeout(struct gswip_priv *priv, u32 offset,
 				  u32 cleared)
 {
 	return priv->ops->read_timeout(priv, (priv->gswip + (offset * 4)), \
-								cleared, 20, 50000);
+					cleared, 20, 50000);
 }
 
 static u32 gswip_slave_mdio_r(struct gswip_priv *priv, u32 offset)
@@ -1875,5 +1872,5 @@ MODULE_FIRMWARE("lantiq/xrx200_phy11g_a22.bin");
 MODULE_FIRMWARE("lantiq/xrx200_phy22f_a14.bin");
 MODULE_FIRMWARE("lantiq/xrx200_phy22f_a22.bin");
 MODULE_AUTHOR("Hauke Mehrtens <hauke@hauke-m.de>");
-MODULE_DESCRIPTION("Core driver for the MaxLinear / Lantiq / Intel GSW switches");
+MODULE_DESCRIPTION("Core driver for MaxLinear / Lantiq / Intel GSW switches");
 MODULE_LICENSE("GPL v2");

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -6,32 +6,15 @@
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
  * Copyright (C) 2022 Reliable Controls Corporation,
- * 						Harley Sims <hsims@reliablecontrols.com>
+ * 			Harley Sims <hsims@reliablecontrols.com>
  */
 
-/* TODO WARP-5829: determine how many of these includes I can delete */
-#include <linux/clk.h>
-#include <linux/delay.h>
-#include <linux/etherdevice.h>
-#include <linux/firmware.h>
-#include <linux/if_bridge.h>
-#include <linux/if_vlan.h>
 #include <linux/iopoll.h>
-#include <linux/mfd/syscon.h>
 #include <linux/module.h>
-#include <linux/of_mdio.h>
-#include <linux/of_net.h>
 #include <linux/of_platform.h>
-#include <linux/phy.h>
-#include <linux/phylink.h>
 #include <linux/platform_device.h>
-#include <linux/regmap.h>
-#include <linux/reset.h>
-#include <net/dsa.h>
-#include <dt-bindings/mips/lantiq_rcu_gphy.h>
 
 #include "lantiq_gsw.h"
-#include "lantiq_pce.h"
 
 struct gsw_platform {
 	struct platform_device *platform_dev;
@@ -45,13 +28,13 @@ static u32 gsw_platform_read(struct gswip_priv *priv, void *addr)
 }
 
 static u32 gsw_platform_read_timeout(struct gswip_priv *priv, void *addr, 
-								u32 cleared, u32 sleep_us, u32 timeout_us)
+				u32 cleared, u32 sleep_us, u32 timeout_us)
 {
 	u32 val;
 	
 	(void*)priv;
 	return readx_poll_timeout(__raw_readl, addr, val,
-						(val & cleared) == 0, sleep_us, timeout_us);
+				(val & cleared) == 0, sleep_us, timeout_us);
 }
 
 static void gsw_platform_write(struct gswip_priv *priv, void *addr, u32 val)

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -27,7 +27,7 @@ static u32 gsw_platform_read(struct gswip_priv *priv, void *addr)
 	return __raw_readl(addr);
 }
 
-static u32 gsw_platform_read_timeout(struct gswip_priv *priv, void *addr, 
+static int gsw_platform_poll_timeout(struct gswip_priv *priv, void *addr, 
 				u32 cleared, u32 sleep_us, u32 timeout_us)
 {
 	u32 val;
@@ -45,8 +45,8 @@ static void gsw_platform_write(struct gswip_priv *priv, void *addr, u32 val)
 
 static const struct gsw_ops gsw_platform_ops = {
 	.read = gsw_platform_read,
-	.read_timeout = gsw_platform_read_timeout,
 	.write = gsw_platform_write,
+	.poll_timeout = gsw_platform_poll_timeout,
 };
 
 /*-------------------------------------------------------------------------*/


### PR DESCRIPTION
PR ready for final review!

Functional changes:
- Rename read_timeout() to poll_timeout() to more accurately describe functionality.
- Change retval of poll_timeout() to int from u32 (again, for accuracy).
- Perform same change for core driver gswip_switch_r_timeout() function.

Test stuff:
- Add tests for TBAR functionality, register read, write, poll w/ timeout, and compound operations.
- Wrap test function & call in RUN_MDIO_COMM_TESTS define.

Clean-up / housekeeping:
- Remove unnecessary includes.
- Fix line breaks to better conform to kernel style guidelines.