### PR TITLE
WARP-5912: Modify driver to allow target specific register addressing

### DIFF
--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -6,7 +6,7 @@
  * Copyright (C) 2012 John Crispin <john@phrozen.org>
  * Copyright (C) 2017 - 2019 Hauke Mehrtens <hauke@hauke-m.de>
  * Copyright (C) 2022 Reliable Controls Corporation,
- * 						Harley Sims <hsims@reliablecontrols.com>
+ * 			Harley Sims <hsims@reliablecontrols.com>
  *
  * The VLAN and bridge model the GSWIP hardware uses does not directly
  * matches the model DSA uses.
@@ -261,9 +261,9 @@ struct gswip_priv {
 };
 
 struct gsw_ops {
-	u32 (*read)(struct gswip_priv *priv, void *addr);
-	void (*write)(struct gswip_priv *priv, void *addr, u32 val);
-	int (*poll_timeout)(struct gswip_priv *priv, void *addr, \
+	u32 (*read)(struct gswip_priv *priv, void *base, u32 offset);
+	void (*write)(struct gswip_priv *priv, void *base, u32 offset, u32 val);
+	int (*poll_timeout)(struct gswip_priv *priv, void *base, u32 offset, \
 			u32 cleared, u32 sleep_us, u32 timeout_us);
 };
 

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -95,12 +95,12 @@ static const struct gswip_rmon_cnt_desc gswip_rmon_cnt[] = {
 
 static u32 gswip_switch_r(struct gswip_priv *priv, u32 offset)
 {
-	return priv->ops->read(priv, (priv->gswip + (offset * 4)));
+	return priv->ops->read(priv, priv->gswip, offset);
 }
 
 static void gswip_switch_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, (priv->gswip + (offset * 4)), val);
+	priv->ops->write(priv, priv->gswip, offset, val);
 }
 
 static void gswip_switch_mask(struct gswip_priv *priv, u32 clear, u32 set,
@@ -116,18 +116,18 @@ static void gswip_switch_mask(struct gswip_priv *priv, u32 clear, u32 set,
 static int gswip_switch_r_timeout(struct gswip_priv *priv, u32 offset,
 				  u32 cleared)
 {
-	return priv->ops->poll_timeout(priv, (priv->gswip + (offset * 4)), \
+	return priv->ops->poll_timeout(priv, priv->gswip, offset, \
 					cleared, 20, 50000);
 }
 
 static u32 gswip_slave_mdio_r(struct gswip_priv *priv, u32 offset)
 {
-	return priv->ops->read(priv, (priv->mdio + (offset * 4)));
+	return priv->ops->read(priv, priv->mdio, offset);
 }
 
 static void gswip_slave_mdio_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, (priv->mdio + (offset * 4)), val);
+	priv->ops->write(priv, priv->mdio, offset, val);
 }
 
 static void gswip_slave_mdio_mask(struct gswip_priv *priv, u32 clear, u32 set,
@@ -142,12 +142,13 @@ static void gswip_slave_mdio_mask(struct gswip_priv *priv, u32 clear, u32 set,
 
 static u32 gswip_mii_r(struct gswip_priv *priv, u32 offset)
 {
-	return priv->ops->read(priv, (priv->mii + (offset * 4)));
+
+	return priv->ops->read(priv, priv->mii, offset);
 }
 
 static void gswip_mii_w(struct gswip_priv *priv, u32 val, u32 offset)
 {
-	priv->ops->write(priv, (priv->mii + (offset * 4)), val);
+	priv->ops->write(priv, priv->mii, offset, val);
 }
 
 static void gswip_mii_mask(struct gswip_priv *priv, u32 clear, u32 set,

--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -142,7 +142,6 @@ static void gswip_slave_mdio_mask(struct gswip_priv *priv, u32 clear, u32 set,
 
 static u32 gswip_mii_r(struct gswip_priv *priv, u32 offset)
 {
-
 	return priv->ops->read(priv, priv->mii, offset);
 }
 

--- a/drivers/net/dsa/lantiq_gsw_mdio.c
+++ b/drivers/net/dsa/lantiq_gsw_mdio.c
@@ -78,7 +78,7 @@ static u32 gsw_mdio_calculate_reg_addr(struct gswip_priv *priv, \
 			return (u32)priv->mdio + offset;
 		else
 			return (u32)base + offset;
-	} else  if (base == priv->mii) {
+	} else if (base == priv->mii) {
 		switch (offset) {
 		case GSWIP_MII_CFGp(5):
 			return GSW_REG_MII_CFG5;

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -21,26 +21,27 @@ struct gsw_platform {
 	struct gswip_priv common;
 };
 
-static u32 gsw_platform_read(struct gswip_priv *priv, void *addr)
+static u32 gsw_platform_read(struct gswip_priv *priv, void *base, u32 offset)
 {
 	(void)priv;
-	return __raw_readl(addr);
+	return __raw_readl(base + (offset * 4));
 }
 
-static int gsw_platform_poll_timeout(struct gswip_priv *priv, void *addr, 
-				u32 cleared, u32 sleep_us, u32 timeout_us)
+static int gsw_platform_poll_timeout(struct gswip_priv *priv, void *base, \
+			u32 offset, u32 cleared, u32 sleep_us, u32 timeout_us)
 {
 	u32 val;
 	
 	(void)priv;
-	return readx_poll_timeout(__raw_readl, addr, val,
+	return readx_poll_timeout(__raw_readl, base + (offset * 4), val,
 				(val & cleared) == 0, sleep_us, timeout_us);
 }
 
-static void gsw_platform_write(struct gswip_priv *priv, void *addr, u32 val)
+static void gsw_platform_write(struct gswip_priv *priv, void *base, \
+						u32 offset, u32 val)
 {
 	(void)priv;
-	__raw_writel(val, addr);
+	__raw_writel(val, base + (offset * 4));
 }
 
 static const struct gsw_ops gsw_platform_ops = {


### PR DESCRIPTION
- Separate all register address math out into bus-specific driver
functions, passing base & offset as arguments.
- Add new function to calculate final register address for external
parts, incorporating all known exceptions and places where the driver
defines differ from the MaxLinear datasheet / switch API code.
- Update existing test code for changes in function prototypes, as well
as to use better defined register addresses.
- Misc. minor touch-ups & fixes.