### PR TITLE
WARP-5916: Enable probe functionality

### DIFF
--- a/drivers/net/dsa/lantiq_gsw_core.c
+++ b/drivers/net/dsa/lantiq_gsw_core.c
@@ -1780,17 +1780,8 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 	priv->ds->ops = &gswip_switch_ops;
 	priv->dev = dev;
 
-	/* TODO WARP-5828:
-	 * do the external parts have versioning?
-	 * determine where to put this & uncomment
-	 */
-	//version = gswip_switch_r(priv, GSWIP_VERSION);
+	version = gswip_switch_r(priv, GSWIP_VERSION);
 
-	/* TODO WARP-5828:
-	 * determine if this is applicable to external parts
-	 * determine where to put this & uncomment
-	 */
-/*
   	gphy_fw_np = of_get_compatible_child(dev->of_node, "lantiq,gphy-fw");
 	if (gphy_fw_np) {
 		err = gswip_gphy_fw_list(priv, gphy_fw_np, version);
@@ -1800,13 +1791,7 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 			return err;
 		}
 	}
-*/
 
-	/* TODO WARP-5828:
-	 * determine if this is applicable, move to platform probe if not.
-	 * uncomment wherever it ends up.
-	 */
-/* 	
 	mdio_np = of_get_compatible_child(dev->of_node, "lantiq,xrx200-mdio");
 	if (mdio_np) {
 		err = gswip_slave_mdio(priv, mdio_np);
@@ -1815,12 +1800,7 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 			goto put_mdio_node;
 		}
 	}
- */
 
-	/* TODO WARP-5828:
-	 * get register mapping corrected and uncomment
-	 */
-/*
 	err = dsa_register_switch(priv->ds);
 	if (err) {
 		dev_err(dev, "dsa switch register failed: %i\n", err);
@@ -1836,7 +1816,7 @@ int gsw_core_probe(struct gswip_priv *priv, struct device *dev)
 	dev_info(dev, "probed GSWIP version %lx mod %lx\n",
 		 (version & GSWIP_VERSION_REV_MASK) >> GSWIP_VERSION_REV_SHIFT,
 		 (version & GSWIP_VERSION_MOD_MASK) >> GSWIP_VERSION_MOD_SHIFT);
-*/
+	
 	return 0;
 
 disable_switch:


### PR DESCRIPTION
- Uncomment core probe function, verify it runs against updated device tree node that includes definitions for internal PHYs.
See Jira issue for latest DT node I'm using on the dev platform. I expect more changes will be necessary to it. See comment about "gphy-fw"-related function not currently being run.
- Add tests to verify that we can communicate with the GSW's internal PHYs over the switch's internal MDIO bus.
- Add definition of GSW140 part for development board use.