### PR TITLE
WARP-5926: Make DSA-related port numbering changes

### DIFF
--- a/drivers/net/dsa/lantiq_gsw.h
+++ b/drivers/net/dsa/lantiq_gsw.h
@@ -261,10 +261,12 @@ struct gswip_priv {
 };
 
 struct gsw_ops {
-	u32 (*read)(struct gswip_priv *priv, void *base, u32 offset);
-	void (*write)(struct gswip_priv *priv, void *base, u32 offset, u32 val);
-	int (*poll_timeout)(struct gswip_priv *priv, void *base, u32 offset, \
-			u32 cleared, u32 sleep_us, u32 timeout_us);
+	u32 	(*read)(struct gswip_priv *priv, void *base, u32 offset);
+	void 	(*write)(struct gswip_priv *priv, void *base, u32 offset, \
+			u32 val);
+	int 	(*poll_timeout)(struct gswip_priv *priv, void *base, \
+			u32 offset, u32 cleared, u32 sleep_us, u32 timeout_us);
+	bool 	(*check_interface_support)(int port, phy_interface_t interface);
 };
 
 struct gswip_pce_table_entry {

--- a/drivers/net/dsa/lantiq_gsw_platform.c
+++ b/drivers/net/dsa/lantiq_gsw_platform.c
@@ -13,6 +13,7 @@
 #include <linux/module.h>
 #include <linux/of_platform.h>
 #include <linux/platform_device.h>
+#include <linux/phy.h>
 
 #include "lantiq_gsw.h"
 
@@ -44,10 +45,40 @@ static void gsw_platform_write(struct gswip_priv *priv, void *base, \
 	__raw_writel(val, base + (offset * 4));
 }
 
+static bool gsw_platform_check_interface_support(int port, phy_interface_t interface)
+{
+	switch (port) {
+	case 0:
+	case 1:
+		if (!phy_interface_mode_is_rgmii(interface)&&
+			interface != PHY_INTERFACE_MODE_MII &&
+			interface != PHY_INTERFACE_MODE_REVMII &&
+			interface != PHY_INTERFACE_MODE_RMII)
+			return false;
+		break;
+	case 2:
+	case 3:
+	case 4:
+		if (interface != PHY_INTERFACE_MODE_INTERNAL)
+			return false;
+		break;
+	case 5:
+		if (!phy_interface_mode_is_rgmii(interface) &&
+		    interface != PHY_INTERFACE_MODE_INTERNAL)
+			return false;
+		break;
+	default:
+		return false;
+	}
+
+	return true;
+}
+
 static const struct gsw_ops gsw_platform_ops = {
-	.read = gsw_platform_read,
-	.write = gsw_platform_write,
-	.poll_timeout = gsw_platform_poll_timeout,
+	.read 				= gsw_platform_read,
+	.write 				= gsw_platform_write,
+	.poll_timeout 			= gsw_platform_poll_timeout,
+	.check_interface_support 	= gsw_platform_check_interface_support,
 };
 
 /*-------------------------------------------------------------------------*/


### PR DESCRIPTION
- Move per-port PHY interface checks out of the core driver and into the
bus-specific drivers via addition of another "ops" function pointer.
- Add part-specific maximum port check to phy link validate logic.
- Allow "internal" phy-mode value on ports 0-3, SGMII on port 4, and
RGMII on port 5.
- Add additional protection against attempting to R/W from the 0x00 address register.
- Add explanatory comment about unsupported MII PCDU registers.
- Return an error from the poll timeout function if target register is not valid.
- Improve internal MDIO bus test by using LED control register, the value of which does not change based on DSA bring-up success/failure.